### PR TITLE
move the stack_tags values to config.yaml

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,3 +5,6 @@ region: {{ var.region | default("us-east-1") }}
 template_bucket_name: "bootstrap-awss3cloudformationbucket-228n2ojlbvj21"
 template_key_prefix: {{ environment_variable.TRAVIS_BRANCH | default("testing") }}
 admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
+department_tag: "CompOnc"
+project_tag: "iAtlas"
+owner_email_tag: "andrew.lamb@sagebase.org"

--- a/config/prod/iatlas-db.yaml
+++ b/config/prod/iatlas-db.yaml
@@ -4,9 +4,9 @@ dependencies:
   - common/iatlasvpc.yaml
   - prod/iatlas-kms.yaml
 stack_tags:
-  Department: "CompOnc"
-  Project: "iAtlas"
-  OwnerEmail: "andrew.lamb@sagebase.org"
+  Department: {{stack_group_config.department_tag}}
+  Project: {{stack_group_config.project_tag}}
+  OwnerEmail: {{stack_group_config.owner_email_tag}}
 parameters:
   VpcName: iatlasvpc
   KmsKeyName: !stack_output_external iatlas-kms-prod::KmsKey

--- a/config/prod/iatlas-kms.yaml
+++ b/config/prod/iatlas-kms.yaml
@@ -1,6 +1,6 @@
 template_path: kms.yaml
 stack_name: iatlas-kms-prod
 stack_tags:
-  Department: "CompOnc"
-  Project: "iAtlas"
-  OwnerEmail: "andrew.lamb@sagebase.org"
+  Department: {{stack_group_config.department_tag}}
+  Project: {{stack_group_config.project_tag}}
+  OwnerEmail: {{stack_group_config.owner_email_tag}}

--- a/config/prod/iatlas-runner.yaml
+++ b/config/prod/iatlas-runner.yaml
@@ -5,9 +5,9 @@ dependencies:
   - prod/iatlas-db.yaml
   - prod/iatlas-kms.yaml
 stack_tags:
-  Department: "CompOnc"
-  Project: "iAtlas"
-  OwnerEmail: "andrew.lamb@sagebase.org"
+  Department: {{stack_group_config.department_tag}}
+  Project: {{stack_group_config.project_tag}}
+  OwnerEmail: {{stack_group_config.owner_email_tag}}
 parameters:
   InstanceType: "t2.nano"
   VpcName: iatlasvpc

--- a/config/staging/iatlas-db.yaml
+++ b/config/staging/iatlas-db.yaml
@@ -4,9 +4,9 @@ dependencies:
   - common/iatlasvpc.yaml
   - staging/iatlas-kms.yaml
 stack_tags:
-  Department: "CompOnc"
-  Project: "iAtlas"
-  OwnerEmail: "andrew.lamb@sagebase.org"
+  Department: {{stack_group_config.department_tag}}
+  Project: {{stack_group_config.project_tag}}
+  OwnerEmail: {{stack_group_config.owner_email_tag}}
 parameters:
   VpcName: iatlasvpc
   KmsKeyName: !stack_output_external iatlas-kms-staging::KmsKey

--- a/config/staging/iatlas-kms.yaml
+++ b/config/staging/iatlas-kms.yaml
@@ -1,6 +1,6 @@
 template_path: kms.yaml
 stack_name: iatlas-kms-staging
 stack_tags:
-  Department: "CompOnc"
-  Project: "iAtlas"
-  OwnerEmail: "andrew.lamb@sagebase.org"
+  Department: {{stack_group_config.department_tag}}
+  Project: {{stack_group_config.project_tag}}
+  OwnerEmail: {{stack_group_config.owner_email_tag}}

--- a/config/staging/iatlas-runner.yaml
+++ b/config/staging/iatlas-runner.yaml
@@ -5,9 +5,9 @@ dependencies:
   - staging/iatlas-db.yaml
   - staging/iatlas-kms.yaml
 stack_tags:
-  Department: "CompOnc"
-  Project: "iAtlas"
-  OwnerEmail: "andrew.lamb@sagebase.org"
+  Department: {{stack_group_config.department_tag}}
+  Project: {{stack_group_config.project_tag}}
+  OwnerEmail: {{stack_group_config.owner_email_tag}}
 parameters:
   InstanceType: "t2.nano"
   VpcName: iatlasvpc


### PR DESCRIPTION
First pass at de-duplicating the config directives

We could also use the Transform function, but it is only able to pull the snippet from a S3 bucket, which might be overcomplicating it.  https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-transform.html#intrinsic-function-reference-transform-examples