### PR TITLE
patch: [#176502085] Added ecs UpdateSevice permissions for the runner…

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,8 +6,14 @@ domain_name: {{ environment_variable.DOMAIN_NAME | default('cri-iatlas.org') }}
 sub_domain_name: {{ environment_variable.SUB_DOMAIN_NAME | default('api') }}
 domain_name_staging: {{ environment_variable.DOMAIN_NAME_STAGING | default('cri-iatlas.org') }}
 sub_domain_name_staging: {{ environment_variable.SUB_DOMAIN_NAME_STAGING | default('api-staging') }}
+gitlab_container_pass: {{ environment_variable.GITLAB_CONTAINER_PASS | default('_NOT_REAL_') }}
+gitlab_container_user: {{ environment_variable.GITLAB_CONTAINER_USER | default('_WILL_NOT_WORK_') }}
 # DO NOT store the token in git.
 gitlab_reg_token: {{ environment_variable.GITLAB_REG_TOKEN | default('_NEVER_GONNA_GET_IT_') }}
+ecs_cluster_name_prod: 'iatlas-prod-EcsCluster'
+ecs_service_name_prod: 'iatlas-prod-EcsService'
+ecs_cluster_name_staging: 'iatlas-staging-EcsCluster'
+ecs_service_name_staging: 'iatlas-staging-EcsService'
 # template_bucket_name: 'bootstrap-awss3cloudformationbucket-114n2ojlbvj21'
 template_key_prefix: {{ environment_variable.TRAVIS_BRANCH | default('testing') }}
 admincentral_cf_bucket: 'bootstrap-awss3cloudformationbucket-19qromfd235z9'

--- a/config/prod/iatlas-api.yaml
+++ b/config/prod/iatlas-api.yaml
@@ -10,9 +10,12 @@ stack_tags: {{stack_group_config.stack_tags}}
 parameters:
   InstanceType: 't3a.medium'
   KeyName: 'iatlas-api-prod' # For this to work, this key must be added in the SAGE AWS.
+  GitLabContainerSecretName: 'gitlab_registry_creds_prod'
+  GitLabContainerPass: {{stack_group_config.gitlab_container_pass}}
+  GitLabContainerUser: {{stack_group_config.gitlab_container_user}}
   VpcId: !stack_output_external iatlasvpc::VPCId
-  ClusterName: 'iatlas-prod-EcsCluster'
-  ServiceName: 'iatlas-prod-EcsService'
+  ClusterName: {{stack_group_config.ecs_cluster_name_prod}}
+  ServiceName: {{stack_group_config.ecs_service_name_prod}}
   BastionHostSgId: !stack_output_external iatlasvpc::BastianSecurityGroup
   PublicSubnetIds:
     - !stack_output_external iatlasvpc::PublicSubnet

--- a/config/prod/iatlas-runner.yaml
+++ b/config/prod/iatlas-runner.yaml
@@ -12,6 +12,8 @@ parameters:
     - !stack_output_external iatlasvpc::PrivateSubnet1
     - !stack_output_external iatlasvpc::PrivateSubnet2
   KeyName: 'iatlas-gitlab-runner-prod'
+  EcsClusterName: {{stack_group_config.ecs_cluster_name_prod}}
+  EcsServiceName: {{stack_group_config.ecs_service_name_prod}}
   DbHost: !stack_output_external iatlasdb-prod::ClusterEndpoint
   DbPort: !stack_output_external iatlasdb-prod::ClusterPort
   DbCredsArn: !stack_output_external iatlasdb-prod::DbCredsArn

--- a/config/staging/iatlas-api.yaml
+++ b/config/staging/iatlas-api.yaml
@@ -10,9 +10,12 @@ stack_tags: {{stack_group_config.stack_tags}}
 parameters:
   InstanceType: 't3a.large'
   KeyName: 'iatlas-api-staging' # For this to work, this key must be added in the SAGE AWS.
+  GitLabContainerSecretName: 'gitlab_registry_creds_staging'
+  GitLabContainerPass: {{stack_group_config.gitlab_container_pass}}
+  GitLabContainerUser: {{stack_group_config.gitlab_container_user}}
   VpcId: !stack_output_external iatlasvpc::VPCId
-  ClusterName: 'iatlas-staging-EcsCluster'
-  ServiceName: 'iatlas-staging-EcsService'
+  ClusterName: {{stack_group_config.ecs_cluster_name_staging}}
+  ServiceName: {{stack_group_config.ecs_service_name_staging}}
   BastionHostSgId: !stack_output_external iatlasvpc::BastianSecurityGroup
   PublicSubnetIds:
     - !stack_output_external iatlasvpc::PublicSubnet

--- a/config/staging/iatlas-runner.yaml
+++ b/config/staging/iatlas-runner.yaml
@@ -12,6 +12,8 @@ parameters:
     - !stack_output_external iatlasvpc::PrivateSubnet1
     - !stack_output_external iatlasvpc::PrivateSubnet2
   KeyName: 'iatlas-gitlab-runner-staging'
+  EcsClusterName: {{stack_group_config.ecs_cluster_name_staging}}
+  EcsServiceName: {{stack_group_config.ecs_service_name_staging}}
   DbHost: !stack_output_external iatlasdb-staging::ClusterEndpoint
   DbPort: !stack_output_external iatlasdb-staging::ClusterPort
   DbCredsArn: !stack_output_external iatlasdb-staging::DbCredsArn

--- a/templates/ecs.yaml
+++ b/templates/ecs.yaml
@@ -3,6 +3,15 @@ Parameters:
   KeyName:
     Type: AWS::EC2::KeyPair::KeyName
     Description: Name of an existing EC2 KeyPair to enable SSH access to the ECS instances.
+  GitLabContainerSecretName:
+    Description: Name of the secret that holds the credentials for accessing the GitLab container registry.
+    Type: String
+  GitLabContainerUser:
+    Description: The user used to access the GitLab container registry (generated on GitLab when generating the access token).
+    Type: String
+  GitLabContainerPass:
+    Description: The password (access token) used to access the GitLab container registry (generated on GitLab).
+    Type: String
   HostedZone:
     Type: String
     Description: The hosted zone in Route 53 for the Load balancer.
@@ -97,6 +106,21 @@ Parameters:
     Description: 'Encryption key ARN to use for storage'
     Type: String
 Resources:
+  ###############
+  ### Secrets ###
+  ###############
+  ContainerRegistrySecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Username and password for the container registry in GitLab
+      KmsKeyId: !Ref KmsKeyArn
+      Name: !Ref 'GitLabContainerSecretName'
+      GenerateSecretString:
+        SecretStringTemplate: !Sub '{"username": "${GitLabContainerUser}", "password": "${GitLabContainerPass}"}'
+      Tags:
+        - Key: Name
+          Value: gitlab-container-registry-secret
+
   ########################
   ### Managed Policies ###
   ########################
@@ -114,7 +138,7 @@ Resources:
             Resource:
               - !Ref 'KmsKeyArn'
               - !Ref 'DbCredsArn'
-              - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:iatlas_gitlab_registry_creds-??????'
+              - !Ref 'ContainerRegistrySecret'
           - Effect: Allow
             Action:
               - logs:CreateLogStream
@@ -319,7 +343,7 @@ Resources:
           Essential: true
           Image: !Sub 'registry.gitlab.com/cri-iatlas/iatlas-api:${DockerImageTag}'
           RepositoryCredentials:
-            CredentialsParameter: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:iatlas_gitlab_registry_creds'
+            CredentialsParameter: !Ref 'ContainerRegistrySecret'
           Memory: 300
           LogConfiguration:
             LogDriver: awslogs

--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -56,6 +56,12 @@ Parameters:
     Description: Maximum number of Runner server instances (managers) in Auto scaling group
     Type: Number
     Default: 1
+  EcsClusterName:
+    Description: The name of the ECS Cluster that the runner is allowed to update the service of.
+    Type: String
+  EcsServiceName:
+    Description: The name of the ECS Service that the runner is allowed to update.
+    Type: String
   GitLabUrl:
     Type: 'String'
     Description: GitLab instance URL. If there is a dedicated GitLab instance, pass the host url, otherwise use the default https://gitlab.com
@@ -271,6 +277,21 @@ Resources:
             Action:
               - logs:CreateLogStream
             Resource: '*'
+  EcsPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Action:
+              - 'ecs:UpdateService'
+            Resource: !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/${EcsClusterName}/${EcsServiceName}
+            Condition:
+              StringEqualsIfExists:
+                'ec2:Region': !Ref 'AWS::Region'
+              ArnEqualsIfExists:
+                'ec2:Vpc': !Sub 'arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/${VpcId}'
 
   ####################################
   ### S3 Bucket for Runners' cache ###
@@ -357,6 +378,7 @@ Resources:
               - 'sts:AssumeRole'
       ManagedPolicyArns:
         - !Ref AccessSecretPolicy
+        - !Ref EcsPolicy
 
   #########################
   ### Instance Profiles ###


### PR DESCRIPTION
…. ECS now creates the gitlab registry sercret in the secret manager and references it to the api.

PR Checklist:
[x] Describe and explain your intentions for this change
Updates to the sceptre scripts to allow the runner access to update the ecs service. Also generating the gitlab registry secret in the secret manager.

[x] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`
