### PR TITLE
patch/test: [#176502085] Removed unused param.

### DIFF
--- a/templates/gitlab-manager-runner.yaml
+++ b/templates/gitlab-manager-runner.yaml
@@ -8,7 +8,6 @@ Metadata:
         Parameters:
           - 'ManagerImageId'
           - 'ManagerInstanceType'
-          - 'KeyName'
           - 'GitLabRunnerInstanceType'
           - 'MinNumInstances'
           - 'MaxNumInstances'


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change
Removed unused param that was making CI fail.

[x] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`
    This is constantly failing. cfn-lint throws error: ImportError: cannot import name 'networkx' from 'networkx'
