### PR TITLE
Updated API instance type to `r5.large`.

### DIFF
--- a/config/prod/iatlas-api.yaml
+++ b/config/prod/iatlas-api.yaml
@@ -11,7 +11,7 @@ dependencies:
   - prod/iatlas-api-roles.yaml
 stack_tags: {{stack_group_config.stack_tags}}
 parameters:
-  InstanceType: 't3a.large'
+  InstanceType: 'r5.large'
   GitLabContainerSecretName: 'gitlab_registry_creds_prod'
   GitLabContainerPass: {{stack_group_config.gitlab_container_pass}}
   GitLabContainerUser: {{stack_group_config.gitlab_container_user}}

--- a/config/staging/iatlas-api.yaml
+++ b/config/staging/iatlas-api.yaml
@@ -11,7 +11,7 @@ dependencies:
   - staging/iatlas-api-roles.yaml
 stack_tags: {{stack_group_config.stack_tags}}
 parameters:
-  InstanceType: 't3a.large'
+  InstanceType: 'r5.large'
   GitLabContainerSecretName: 'gitlab_registry_creds_staging'
   GitLabContainerPass: {{stack_group_config.gitlab_container_pass}}
   GitLabContainerUser: {{stack_group_config.gitlab_container_user}}

--- a/templates/gitlab-manager-runner-roles.yaml
+++ b/templates/gitlab-manager-runner-roles.yaml
@@ -37,7 +37,6 @@ Parameters:
       - 'r5a.xlarge'
       - 'r5a.2xlarge'
       - 'r5a.4xlarge'
-      - 'r5a.8xlarge'
     Default: 't3a.micro'
     ConstraintDescription: must be a valid EC2 instance type
   VpcId:


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change
The API is running out of memory as it processes larger and larger datasets. The `t3a.large` that it is built on is 2 vCPUs and 8G memory.
We are updating to a memory optimized instance, an `r5.large`; it has more memory per vCPU with 2vCPUs and 16G memory.

[X] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`
